### PR TITLE
[hugo-updater] Update Hugo to version 0.88.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.87.0"
+  HUGO_VERSION = "0.88.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.88.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.88.1



This is a bug-fix release with one important fix.

* Bump down again to Go 1.16.7 for the release builds [e1ead4db](https://github.com/gohugoio/hugo/commit/e1ead4dbca4cfb00ec0893c8c8563c91624ecca7) [@bep](https://github.com/bep) [#8952](https://github.com/gohugoio/hugo/issues/8952)[#8955](https://github.com/gohugoio/hugo/issues/8955)




