### PR TITLE
[hugo-updater] Update Hugo to version 0.89.4

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.88.1"
+  HUGO_VERSION = "0.89.4"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.89.4
More details in https://github.com/gohugoio/hugo/releases/tag/v0.89.4

This is a bug-fix release with one important fix for people using `hugo new` to create new content:

* Fix content dir resolution when main project is a Hugo Module [2e70f61f](https://github.com/gohugoio/hugo/commit/2e70f61fb04cea08ef6598728a57637ae2cc199c) [@bep](https://github.com/bep) [#9177](https://github.com/gohugoio/hugo/issues/9177)




