### PR TITLE
[hugo-updater] Update Hugo to version 0.90.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.89.4"
+  HUGO_VERSION = "0.90.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.90.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.90.1

This release contains some fixes and improvements related to error handling in remote lookups in `resources.Get`, as introduced in Hugo 0.90.0:

* Now we will always return `nil` (never fail the build) when a _resource is not found_, also for remote resources (HTTP status code 404). This means that you can do `{{ with $img }}{{ else }}{{/* insert a default image or something */}}{{ end }}` and similar constructs, not having to consider where the resource source lives.
* Fetching resources remotely over HTTPS has a much greater chance of failing (network down, server down) than reading a file from disk (if not already [cached](https://gohugo.io/getting-started/configuration/#configure-file-caches)). And having this lead to a failing build is not always optimal. This release allows you to handle/ignore these errors in the templates if needed, see details below.

The return value from `resources.Get` now includes an `.Err` method that will be set if the call failed. If you want to just log any error as a `WARNING` you can use a construct similar to the one below.

```htmlbars
{{ with resources.Get "https://gohugo.io/images/gohugoio-card-1.png" }}
  {{ with .Err }}
    {{ warnf "%s" . }}
  {{ else }}
    <img src="{{ .RelPermalink }}" width="{{ .Width }}" height="{{ .Height }}" alt="">
  {{ end }}
{{ end }}
```
Note that if you do not handle `.Err` yourself, Hugo will fail the build the first time you start using the failed `Resource` object.

## Changes

* Remove the retries on error in remote resources.Get 3bc68304 [@bep](https://github.com/bep) #9271 
* Allow user to handle/ignore errors in resources.Get e4d6ec94 [@bep](https://github.com/bep) #9259 
* Make resource.Get return nil on 404 not found 6260455b [@bep](https://github.com/bep) #9267 
* Update to Go 1.17.5 c397975a [@bep](https://github.com/bep) #9269 
* Update to Go 1.17.4 and remove timeout in resources.Get 965a6cbf [@bep](https://github.com/bep) #9265 




