### PR TITLE
[hugo-updater] Update Hugo to version 0.92.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
+  HUGO_VERSION = "0.92.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.92.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.92.0

Hugo `0.92.0` is mostly a release to prepare for some cool stuff coming in the next releases. Most notable are the deprecation updates:

* The `.Page` methods marked as deprecated in Hugo 0.55 are now removed. They have been logged as an `ERROR` for a long time now and you will still get a clear error if you use them.
* The support for `MMark` as a Markdown engine is removed. That has been marked as deprecated for a long time, and the upstream library is also deprecated and unmaintained.
* If you use `.Path` on a `Page` that is backed by a file, you will now get a warning. More on that below.

The `.Path` method on `Page` works like before. But that method currently has a little vague specification – it behaves a little different if backed by a file. In Hugo `0.93` we're going to introduce a _canonical content path_, and to prepare for that change, you may see this in your log:

```bash
WARN 2022/01/12 10:23:37 .Path when the page is backed by a file is deprecated and will be removed in a future release. We plan to use Path for a canonical source path and you probably want to check the source is a file. To get the current behaviour, you can use a construct simlar to the below:

  {{ $path := "" }}
  {{ with .File }}
	{{ $path = .Path }}
  {{ else }}
	{{ $path = .Path }}
  {{ end }}


Re-run Hugo with the flag --panicOnWarning to get a better error message.
```

`.Path` is commonly used to create links to the source on GitHub – and that obviously only works for files, so you, as suggested above, may want to check if it's a file first.

Note that the `--panicOnWarning` flag is a new flag in this release and works for all warnings – it will fail fast on the first warning and point to the line in question. This makes it much easier to pin-point the location.

But this release isn't all about technical upgrades. We have also added a new `hugo.Deps` template function. We have already a way to list the Hugo Modules dependencies from the command line (`hugo mod graph`), but we thought it would be useful to also record this into your rendered site. An example of a "dependency table" in HTML may look like this:

```htmlbars
<h2>Dependencies</h2>
<table class="table table-dark">
    <thead>
    <tr>
        <th scope="col">#</th>
        <th scope="col">Owner</th>
        <th scope="col">Path</th>
        <th scope="col">Version</th>
        <th scope="col">Time</th>
        <th scope="col">Vendor</th>
    </tr>
    </thead>
    <tbody>
    {{ range $i, $e := hugo.Deps }}
    <tr>
        <th scope="row">{{ add $i 1 }}</th>
        <td>{{ with .Owner }}{{.Path }}{{ end }}</td>
        <td>
        {{ .Path }}
        {{ with .Replace}}
        => {{ .Path }}
        {{ end }}
        </td>
        <td>{{ .Version }}</td>
        <td>{{ with .Time }}{{ . }}{{ end }}</td>
        <td>{{ .Vendor }}</td>
    </tr>
    {{ end }}
    </tbody>
</table>
```
This release represents **41 contributions by 4 contributors** to the main Hugo code base.[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@jmooring](https://github.com/jmooring), [@ptgott](https://github.com/ptgott), and [@roointan](https://github.com/roointan) for their ongoing contributions.
And thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his ongoing work on keeping the themes site in pristine condition.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs),
which has received **9 contributions by 4 contributors**. A special thanks to [@bep](https://github.com/bep), [@jmooring](https://github.com/jmooring), [@anarchivist](https://github.com/anarchivist), and [@davidsneighbour](https://github.com/davidsneighbour) for their work on the documentation site.


Hugo now has:

* 56338+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 431+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 415+ [themes](http://themes.gohugo.io/)


## Notes

* Make the deprecated Page/File methods (from Hugo 0.55) ERROR 56ab83a5 [@bep](https://github.com/bep) #9346 
* releaser: Add release notes for 0.91.2 [ci skip] f0b55a68 [@bep](https://github.com/bep) 
* releaser: Add release notes for 0.91.1 [ci skip] af165d5b [@bep](https://github.com/bep) 


## Changes

* docs: Regenerate docshelper f2bc13dd [@bep](https://github.com/bep) 
* Only create LazyContentProvider for the non-rendering Site cdcd15b6 [@bep](https://github.com/bep) #8919 
* Fix missing page data for alternative formats 25d645f4 [@ptgott](https://github.com/ptgott) #8919 
* docs: Add dependency table to maintainance page fbb3c181 [@bep](https://github.com/bep) #8949 
* deps: Upgrade github.com/evanw/esbuild v0.14.8 => v0.14.11 9af4ca38 [@bep](https://github.com/bep) 
* Add hugo.Deps 7396aa94 [@bep](https://github.com/bep) #8949 
* hugolib: Fix livereload problem with files including NFC characters in MacOs d82cef5c [@roointan](https://github.com/roointan) #8429 
* docs. Regen CLI docs 74f0777c [@bep](https://github.com/bep) #9363 
* commands: Fix CLI help text for hugo new e334a406 [@bep](https://github.com/bep) #9363 
* Update to Go 1.17.6 5bd3c8df [@bep](https://github.com/bep) #9361 
* create: Correctly pass newContentEditor flags 0aca99fe [@jmooring](https://github.com/jmooring) #9356 
* Add --panicOnWarning flag c8b5ab75 [@bep](https://github.com/bep) #9357 #9359 
* github: Increase stale days 85c5b895 [@bep](https://github.com/bep) 
* docs: Regenerate CLI docs 96576083 [@bep](https://github.com/bep) 
* docs: Regenerate docshelper 4a0b5533 [@bep](https://github.com/bep) 
* Remove mmark 1651beb2 [@bep](https://github.com/bep) #9350 
* Misc depreation updates 2b6063c3 [@bep](https://github.com/bep) #9348 #9349 
* Make the deprecated Page/File methods (from Hugo 0.55) ERROR 56ab83a5 [@bep](https://github.com/bep) #9346 
* github: Add add stale GitHub action dad0dc8d [@bep](https://github.com/bep) 
* Fix surprise OutputFormat.Rel overwriting d3c4fdb8 [@ptgott](https://github.com/ptgott) #8030 
* hugolib: Make an RST test optional d632dd7d [@bep](https://github.com/bep) 
* deps: Upgrade github.com/niklasfasching/go-org v1.5.0 => v1.6.0 0671ef55 [@jmooring](https://github.com/jmooring) #8921 
* Update stale.yml 672481f1 [@bep](https://github.com/bep) 
* releaser: Prepare repository for 0.92.0-DEV 1dbfc0f9 [@bep](https://github.com/bep) 
* releaser: Bump versions for release of 0.91.2 1798bd3f [@bep](https://github.com/bep) 
* releaser: Add release notes for 0.91.2 [ci skip] f0b55a68 [@bep](https://github.com/bep) 
* Revert "config/security: Add HOME to default exec env var whitelist" 623dda71 [@bep](https://github.com/bep) 
* Make sure we always create the /public folder aee9e11a [@bep](https://github.com/bep) #8166 
* Fix "stuck on build" in error situations in content processing bd63c1aa [@bep](https://github.com/bep) #8166 
* deps: Run "go mod tidy" 9eb05807 [@bep](https://github.com/bep) 
* deps: Upgrade github.com/evanw/esbuild v0.14.7 => v0.14.8 654f513a [@bep](https://github.com/bep) 
* releaser: Prepare repository for 0.92.0-DEV 759cdf3f [@bep](https://github.com/bep) 
* releaser: Bump versions for release of 0.91.1 f4235057 [@bep](https://github.com/bep) 
* releaser: Add release notes for 0.91.1 [ci skip] af165d5b [@bep](https://github.com/bep) 
* media: Also consider extension in FromContent 6779117f [@bep](https://github.com/bep) 
* media: Add missing BMP and GIF to the default MediaTypes list ce040110 [@bep](https://github.com/bep) 
* media: Add PDF MIME type cdc73526 [@bep](https://github.com/bep) 
* deps: Update github.com/evanw/esbuild v0.14.5 => v0.14.7 425c7d90 [@bep](https://github.com/bep) 
* config/security: Add HOME to default exec env var whitelist fca266eb [@bep](https://github.com/bep) #9309 
* modules: Set GOCACHE env var 0016e21c [@bep](https://github.com/bep) #9309 
* releaser: Prepare repository for 0.92.0-DEV 728feaec [@bep](https://github.com/bep) 






