### PR TITLE
[hugo-updater] Update Hugo to version 0.92.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
+  HUGO_VERSION = "0.92.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.92.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.92.1



This is a bug-fix release with a couple of important fixes.

* Make the RenderString content provider fix more general f22c4aba [@bep](https://github.com/bep) #9383 
* Fix .RenderString issue in .Translations 85d31f7b [@ptgott](https://github.com/ptgott) #9383 
* general: Fix issue causing log threads to hang indefinitely when print() panics 22055176 [@Ephex2](https://github.com/Ephex2) #9380 
* Fix duplicate mount sources 7a080b62 [@bep](https://github.com/bep) #9426 
* tpl/collections: Fix apply with namespaced template funcs 26557399 [@bep](https://github.com/bep) #9393 
* common: Remove unused code 348d300a [@bep](https://github.com/bep) 
* common/paths: Remove unused code 6f07bdb1 [@bep](https://github.com/bep) 
* helpers: Remove unused code 55a9bc1e [@bep](https://github.com/bep) 
* Do not render hl_style as an HTML attribute 20a7ce7c [@jmooring](https://github.com/jmooring) #9390 
* build(deps): bump github.com/spf13/viper from 1.8.1 to 1.10.1 8cd44924 [@dependabot[bot]](https://github.com/apps/dependabot) 
* Fixing typos (#9387) 9d8f318a [@deining](https://github.com/deining) 
* Fix typo in warning message fcbbbef2 [@deining](https://github.com/deining) 
* github: Clean up the issue templates a little 6041adc1 [@bep](https://github.com/bep) 
* github: Add lock-threads step 408da436 [@bep](https://github.com/bep) 




