### PR TITLE
[hugo-updater] Update Hugo to version 0.92.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.92.1"
+  HUGO_VERSION = "0.92.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.92.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.92.2



This is a bug-fix release with a couple of important fixes.

* Add HUGO_ENV to the os/exec environment 4f4cec73 [@jmooring](https://github.com/jmooring) #9490 
* Simplify some integration tests da4866c2 [@bep](https://github.com/bep) 
* Fix validation of Page Kind in cascade target map d1109f59 [@jmooring](https://github.com/jmooring) #8888 
* Add another cascade benchmark a7d182ce [@bep](https://github.com/bep) 
* commands: Fix server deadlock on config error a2a660ed [@bep](https://github.com/bep) #9486 
* Exclude event attributes when rendering markdown f7bc4cc5 [@jmooring](https://github.com/jmooring) #9463 
* Remove the "check" command 54f8d8a7 [@jmooring](https://github.com/jmooring) #9454 
* Update the application/javascript media type 3036d0ac [@jmooring](https://github.com/jmooring) #9483 
* tpl/templates: Fix templates.Exist issue with base templates 6a238a72 [@bep](https://github.com/bep) #9477 
* Add a migration test helper f60714b5 [@bep](https://github.com/bep) 
* babel: Port integration tests to their own package 215a715d [@bep](https://github.com/bep) 
* js: Port integration tests to its own package d128d260 [@bep](https://github.com/bep) 
* postcss: Move integration test to its own package c4aaf1d5 [@bep](https://github.com/bep) 
* minifier: Port integration tests to its package 94f10cf4 [@bep](https://github.com/bep) 
* templates: Port integration test to its package b06c2103 [@bep](https://github.com/bep) 
* tocss: Port integration tests to their package d22f7795 [@bep](https://github.com/bep) 
* openapi3: Port integration test into correct package 39f69ca7 [@bep](https://github.com/bep) 
* Add a new integration test framework 64f75adc [@bep](https://github.com/bep) 
* Validate comparison operator argument count 92627190 [@jmooring](https://github.com/jmooring) #9462 
* Remove hugo gen autocomplete 33367629 [@jmooring](https://github.com/jmooring) #8862 
* deps: Update github.com/pelletier/go-toml/v2 to v2.0.0-beta.6 5ca40c8f [@bep](https://github.com/bep) #9439 #9417 
* Fix erroneous warning with .Page.RenderString on a page without a backing file ef7d14a2 [@bep](https://github.com/bep) #9433 
* Fix typo in panicOnWarning message c05c99f0 [@jmooring](https://github.com/jmooring) 
* releaser: Prepare repository for 0.93.0-DEV ff7689ce [@bep](https://github.com/bep) 




