### PR TITLE
[hugo-updater] Update Hugo to version 0.94.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.93.2"
+  HUGO_VERSION = "0.94.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.94.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.94.2

This is a bug-fix release that fixes a bug introduced in the bug fix release yesterday (some HTML comments in Markdown that made the parser panic):

* deps: Update github.com/yuin/goldmark v1.4.9 => v1.4.10 b37183e4 @bep #9658 





