### PR TITLE
[hugo-updater] Update Hugo to version 0.96.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.95.0"
+  HUGO_VERSION = "0.96.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.96.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.96.0

**Vertical merging of content mounts.** The main topic of this release is about file mounts (see #9693). We have had a powerful and well defined merge strategy for the union filesystems for the Hugo Modules tree on the horizontal axis (left to right), but not so much for the vertical configuration within each module (e.g. multiple content mounts for the same language). It was @jmooring who [pointed out](https://discourse.gohugo.io/t/do-all-page-bundles-need-localized-copies-once-you-add-a-new-language/37225/12?u=bep) how useful this could be, and even provided this example where missing translations gets filled in from other language(s):

```toml
#------------------------------------------------------------------------------
# Content mounts
#------------------------------------------------------------------------------

# EN content
[[module.mounts]]
source = 'content/en'
target = 'content'
lang = 'en'

# DE content
[[module.mounts]]
source = 'content/de'
target = 'content'
lang = 'de'

# NL content
[[module.mounts]]
source = 'content/nl'
target = 'content'
lang = 'nl'

#------------------------------------------------------------------------------
# Fill in the missing translations
#------------------------------------------------------------------------------

# This fills in the gaps in DE content with EN content
[[module.mounts]]
source = 'content/en'
target = 'content'
lang = 'de'

# This fills in the gaps in NL content with EN content.
[[module.mounts]]
source = 'content/en'
target = 'content'
lang = 'nl'
```

Also, we have added some details to the `.Err` object you get when `resources.GetRemote` fails, which can be useful when debugging errrors (see #9708). Not you can do something like:

```htmlbars
{{ with $result := resources.GetRemote $url }}
  {{ with .Err }}
    {{ warnf "%s: %#v" .Error .Data}}
  {{ else }}
    {{ with .Content | unmarshal }}
      {{ warnf "%#v" . }}
    {{ end }}
  {{ end }}
{{ end }}
```

The `.Data` object above is a `map` and currently contains `StatusCode`, `Status`, `Body`, `TransferEncoding`, `ContentLength`, and `ContentType`.

This release represents **23 contributions by 8 contributors** to the main Hugo code base.[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@jmooring](https://github.com/jmooring), [@dependabot[bot]](https://github.com/apps/dependabot), and [@anthonyfok](https://github.com/anthonyfok) for their ongoing contributions.
And thanks to [@digitalcraftsman](https://github.com/digitalcraftsman) for his ongoing work on keeping the themes site in pristine condition.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs),
which has received **5 contributions by 3 contributors**.

Hugo now has:

* 57897+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 429+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 397+ [themes](http://themes.gohugo.io/)


## Notes

* Deprecate .File.Extension 94459680 @sara-meie #9352 


## Changes

* docs: Regen docshelper db1562e1 @bep 
* docs: Regen CLI docs 5b18e108 @bep 
* Deprecate .File.Extension 94459680 @sara-meie #9352 
* resources: Add more details to .Err 9202117b @bep #9708 
* commands: Change link protocol to https a6fa290f @jmooring 
* build(deps): bump github.com/getkin/kin-openapi from 0.91.0 to 0.93.0 0bbc2fb5 @dependabot[bot] 
* tpl/crypto: Add optional encoding arg to hmac function 94e8a907 @jmooring #9709 
* Fix typo a461e9d0 @panakour 
* Fix some typos 48c98a8d @cuishuang 
* Update CONTRIBUTING.md to use "go install" to install mage bbd455fe @anthonyfok 
* Dockerfile: Make it build with Go 1.18 8309a2b1 @anthonyfok 
* snap: Make it build with Go 1.18 2b723109 @anthonyfok 
* build(deps): bump github.com/yuin/goldmark from 1.4.10 to 1.4.11 13ff4ded @dependabot[bot] 
* build(deps): bump github.com/spf13/cobra from 1.3.0 to 1.4.0 c3289eb5 @dependabot[bot] 
* commands: Improve server startup to make tests less flaky 9539069f @bep 
* all: Use strings.Cut 0e305d69 @bep #9687 
* Support '-u=patch' in hugo mod get 5adb81ce @LukeDeWaal #9127 
* Make sure file mounts higher up wins 1c0e7c1a @bep #9693 
* resources/images: Require width and height for Crop, Fill, and Fit cad2d8cc @jmooring #9696 
* all: gofmt -w -r 'interface{} -> any' . b80853de @bep #9687 
* dartsass: Enable deprecation, @warn and @debug logging 423594e0 @bep #9683 
* Use revision etc. from debug.BuildInfo 64afb7ca @bep #9680 
* releaser: Prepare repository for 0.96.0-DEV 004bec2e @bep 






