### PR TITLE
[hugo-updater] Update Hugo to version 0.98.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.97.3"
+  HUGO_VERSION = "0.98.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.98.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.98.0

This release is mostly some important upgrades of Hugo's core dependencies, but we have also added `crypto.FNV32a` template function, which produces 32-bit unsigned integer hashes from a string. We have already many hash functions, but none of them produces an integer, which can be useful, e.g.:

```htmlbars
{{ $mystring := "Hugo" }}
{{ $colors := slice "orange" "blue" "green" "steel" "hotpink" }}
{{ $hash := (crypto.FNV32a $mystring) }}
{{ $i := mod $hash (len $colors) }}
{{ $color := index $colors $i }}
```

This release represents **29 contributions by 3 contributors** to the main Hugo code base.

Hugo now has:

* 58549+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 428+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 399+ [themes](http://themes.gohugo.io/)

## Notes

* Deprecate page.Author and page.Authors 097fd588 @bep 

## Changes

* docs: Regen docs helper a4fff575 @bep 
* Some godoc adjustments and image struct renames fa80fe3c @bep 
* tpl/crypto: Add FNV32a 11047534 @bep 
* markup/goldmark: Fix attribute nilpointer d7b54a4c @bep #9819
* deps: Update to gocloud.dev v0.24.0 13ceef75 @bep 
* build(deps): bump github.com/mitchellh/mapstructure from 1.4.3 to 1.5.0 942d0dd2 @dependabot[bot] 
* deps: Update github.com/yuin/goldmark v1.4.11 => v1.4.12 a022ca27 @jmooring #9054 #9756 #9757 
* build(deps): bump github.com/evanw/esbuild from 0.14.36 to 0.14.38 d56b3395 @dependabot[bot] 
* deps: Update github.com/tdewolff/minify/v2 v2.11.1 => v2.11.2 55e28c23 @jmooring #9820 
* Some godoc adjustments 9a888c24 @bep 
* tpl/lang: Handle nil values in lang.Merge 05b45c35 @bep 
* resources/page: Mark some more interface methods as internal 625be77e @bep 
* Deprecate page.Author and page.Authors 097fd588 @bep 
* releaser: Prepare repository for 0.98.0-DEV 41cc4e4b @bep 
* releaser: Bump versions for release of 0.97.3 078053a4 @bep 
* releaser: Add release notes for 0.97.3 [ci skip] 7d9f8880 @bep 
* Fix syncing of /static regression 9b352f04 @bep #9794 #9788 
* Revert "Revert "Fix PostProcess regression for hugo server"" e66e2e9c @bep #9794 
* releaser: Prepare repository for 0.98.0-DEV 5de6f8a0 @bep 
* releaser: Bump versions for release of 0.97.2 5099abe6 @bep 
* releaser: Add release notes for 0.97.2 [ci skip] 99ec88d4 @bep 
* Revert "Fix PostProcess regression for hugo server" 6c35a1a9 @bep 
* releaser: Prepare repository for 0.98.0-DEV 363bc907 @bep 
* releaser: Bump versions for release of 0.97.1 04efcb2a @bep 
* releaser: Add release notes for 0.97.1 [ci skip] 45607255 @bep 
* Fix PostProcess regression for hugo server 4deb5c60 @bep #9788 
* Fix MediaType when reading images from cache 397fce56 @bep #8931 
* deps: Upgrade github.com/bep/overlayfs v0.4.0 => v0.5.0 0093eaa6 @bep #9783 
* releaser: Prepare repository for 0.98.0-DEV d0f731c0 @bep 






