### PR TITLE
[hugo-updater] Update Hugo to version 0.99.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.99.0"
+  HUGO_VERSION = "0.99.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.99.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.99.1

Fix server regression for multihost sites (multiple languages with different baseURLs) 2f9eac48 @bep #9901 





