### PR TITLE
[hugo-updater] Update Hugo to version 0.100.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.99.1"
+  HUGO_VERSION = "0.100.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.100.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.100.1

Fix panic with markdownify/RenderString with shortcode on Page with no content file 212d9e30 @bep #9959 




