### PR TITLE
[hugo-updater] Update Hugo to version 0.100.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.100.1"
+  HUGO_VERSION = "0.100.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.100.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.100.2

This release is mostly motivated by the fix for the panic experienced by people having `blackfriday` configured as `defaultMarkdownHandler` (#9968).  The Blackfriday support was removed in Hugo v0.100.0 after being deprecated with a warning for a long time.

* Fix raw TOML dates in where/eq 0566bbf7 @bep #9979 
* deps: Update to github.com/pelletier/go-toml/v2 v2.0.1 534e7155 @anthonyfok 
* tpl/path: Add path.BaseName function 953f215f @jmooring #9973 
* livereload: Use `X-Forwarded-Host` for Codespace 8e2fd559 @satotake #9936 
* helpers: Fix panic with invalid defaultMarkdownHandler 311b8008 @bep #9968 
* resources: Register MediaTypes before build c7d5f9f0 @vanbroup #9971 




