### PR TITLE
[hugo-updater] Update Hugo to version 0.101.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.100.2"
+  HUGO_VERSION = "0.101.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.101.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.101.0

Hugo `v0.101.0` comes with GIF animation [image processing](https://gohugo.io/content-management/image-processing/), a new `hl_inline` option for code highlighting, a new `:slugorfilename` permalink keyword, we now respect the [NO_COLOR](https://no-color.org/) OS env var, and more.

This release represents **35 contributions by 9 contributors** to the main Hugo code base.[@bep](https://github.com/bep) leads the Hugo development with a significant amount of contributions, but also a big shoutout to [@dependabot[bot]](https://github.com/apps/dependabot), [@jmooring](https://github.com/jmooring), and [@vanbroup](https://github.com/vanbroup) for their ongoing contributions. Also a shoutout to @CIAvash for his work on the Chroma highlighter.

Many have also been busy writing and fixing the documentation in [hugoDocs](https://github.com/gohugoio/hugoDocs),
which has received **3 contributions by 2 contributors**.

Hugo now has:

* 59557+ [stars](https://github.com/gohugoio/hugo/stargazers)
* 428+ [contributors](https://github.com/gohugoio/hugo/graphs/contributors)
* 399+ [themes](http://themes.gohugo.io/)


## Changes

* build: Update to Go 1.18.3 2c5943dd @bep #9964 
* docs: Regen docshelper 0cb459a2 @bep 
* markup/highlight: Add hl_inline option d863dde6 @bep #9442 #9635 #9638 
* deps: Update github.com/alecthomas/chroma/v2 v2.1.0 => v2.2.0 580b214a @bep 
* build(deps): bump github.com/clbanning/mxj/v2 from 2.5.5 to 2.5.6 ddb95470 @dependabot[bot] 
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.0.1 to 2.0.2 288b0fb1 @dependabot[bot] 
* build(deps): bump golang.org/x/tools from 0.1.10 to 0.1.11 3e134463 @dependabot[bot] 
* build(deps): bump github.com/tdewolff/minify/v2 from 2.11.5 to 2.11.10 7a9ce0ec @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.14.42 to 0.14.43 f2ba0cc8 @dependabot[bot] 
* build(deps): bump github.com/getkin/kin-openapi from 0.94.0 to 0.97.0 62ceaabd @dependabot[bot] 
* deps: Udpate to github.com/alecthomas/chroma/v2 35fa1928 @bep #9932 #9931 
* common: Add hugo.GoVersion 09ac7333 @khayyamsaleem #9849 
* resources: Panic on Copy of Resource with .Err 66da1b7b @bep #10006 
* resources/page: Add :slugorfilename attribute 5a9ecb82 @dawidpotocki #385 
* Respect NO_COLOR cbc35c48 @bep #10004 
* readme: Update dependency list 44f3c079 @deining 
* Fix relURL with leading slash when baseURL includes a subdirectory a5a4422a @bep #9994 
* js: Resolve index.esm.js 617e0944 @bep #8631 
* Add animated GIF support cf12fa61 @bep #5030 
* resources: Add a Gif source file to golden tests 2e1c8177 @bep 
* releaser: Prepare repository for 0.101.0-DEV 4276075c @bep 
* releaser: Bump versions for release of 0.100.2 d25cb294 @bep 
* releaser: Add release notes for 0.100.2 [ci skip] 8b9bdc40 @bep 
* Update CONTRIBUTING.md 4e94d1db @bep 
* Fix raw TOML dates in where/eq 0566bbf7 @bep #9979 
* deps: Update to github.com/pelletier/go-toml/v2 v2.0.1 534e7155 @anthonyfok 
* tpl/path: Add path.BaseName function 953f215f @jmooring #9973 
* livereload: Use `X-Forwarded-Host` for Codespace 8e2fd559 @satotake #9936 
* helpers: Fix panic with invalid defaultMarkdownHandler 311b8008 @bep #9968 
* resources: Register MediaTypes before build c7d5f9f0 @vanbroup #9971 
* releaser: Prepare repository for 0.101.0-DEV bfebd8c0 @bep 
* releaser: Bump versions for release of 0.100.1 0afb4866 @bep 
* releaser: Add release notes for 0.100.1 [ci skip] b1ec0c22 @bep 
* Fix panic with markdownify/RenderString with shortcode on Page with no content file 212d9e30 @bep #9959 
* releaser: Prepare repository for 0.101.0-DEV 4daac654 @bep 






