### PR TITLE
[hugo-updater] Update Hugo to version 0.102.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.102.1"
+  HUGO_VERSION = "0.102.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.102.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.102.3

## What's Changed

* Fix shortcode parser regression with quoted param values 8e5044d7 @bep #10236 

