### PR TITLE
[hugo-updater] Update Hugo to version 0.105.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.104.3"
+  HUGO_VERSION = "0.105.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.105.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.105.0

## Bug fixes

* Avoid nilpointer when shortcode page content output nil e5d2a8f6 @davidejones #10391 
* Revise the fix for shortcode vs output format nilpointer 631d768b @bep #10391 

## Improvements

* livereload: Use text/javascript here, too 00ff161b @bep 
* media: Rename application/javascript, application/typescript to text/javascript etc. 588710a7 @bep 
* Skip flakey server tests on GitHub Action on Windows 20ef6dcf @bep 
* github: Avoid duplicate test runs d1cd1db0 @bep 
* tpl/encoding: Add noHTMLEscape option to jsonify 09e10110 @bep 
* Don't use self-closing generator tag 01ebb6e3 @djibe 
* github: Use SHA versions 1fd3320d @bep 
* Resolve dependency-path not found error in workflow 0fb2b3d1 @jongwooo 
* Use setup-go action to cache dependencies db05232d @jongwooo 

## Dependency Updates

* build(deps): bump golang.org/x/tools from 0.1.12 to 0.2.0 f5058544 @dependabot[bot] 
* build(deps): bump github.com/getkin/kin-openapi from 0.106.0 to 0.107.0 2aedccc9 @dependabot[bot] 
* build(deps): bump golang.org/x/text from 0.3.7 to 0.4.0 c1093140 @dependabot[bot] 
* build(deps): bump github.com/spf13/cobra from 1.5.0 to 1.6.1 4732c47d @dependabot[bot] 
* build(deps): bump github.com/getkin/kin-openapi from 0.103.0 to 0.106.0 62780ec8 @dependabot[bot] 
* build(deps): bump github.com/tdewolff/minify/v2 from 2.12.1 to 2.12.4 351d6b06 @dependabot[bot] 
* build(deps): bump github.com/yuin/goldmark from 1.4.15 to 1.5.2 ed930db2 @dependabot[bot] 
* build(deps): bump github.com/fsnotify/fsnotify from 1.5.4 to 1.6.0 05df9648 @dependabot[bot] 
* build(deps): bump github.com/magefile/mage from 1.13.0 to 1.14.0 9860e0e1 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.15.9 to 0.15.12 2ef60dbd @dependabot[bot] 

## Documentation

* Update Go and Alpine version in Dockerfile 6275aad9 @wind0r 

## Build Setup

* build: Update to Go 1.19.2 a066e988 @bep 


