### PR TITLE
[hugo-updater] Update Hugo to version 0.109.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.108.0"
+  HUGO_VERSION = "0.109.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.109.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.109.0

<img src="https://user-images.githubusercontent.com/394382/209377043-7c5e2506-a4a2-46c1-83af-9a77756563a9.png" width=40% height=40% align=right>

Hugo `v0.109.0` is the last release of 2022 – and with that we're wishing all of you a very merry Christmas and a prosperous new year[^1].

## Notable new features
### Pass variables to SCSS/SASS

Hugo has had great SCSS/SASS support, but passing variables (e.g. theme colours from config) down to the transpiler has been much harder than it should.

In Hugo `v0.109.0` we added a new [vars option](https://gohugo.io/hugo-pipes/scss-sass/#options) and you can finally just do:

```handlebars
{{ $vars := dict "color1" "blue" "color2" "green" "font_size" "24px" }}
{{ $opts := (dict "transpiler" "dartsass" "outputStyle" "compressed" "vars" $vars ) }}
{{ $r := resources.Get "scss/main.scss" | toCSS $opts }}
```
And then in the SCSS file:

```scss
@use "hugo:vars" as v;

p {
    color: v.$color1;
    font-size: v.$font-size;
}
```

More examples [here](https://discourse.gohugo.io/t/initialize-sass-variables-from-hugo-templates/42053/).

### Hugo Module Workspaces

Workspace support was added in [Go 1.18](https://go.dev/blog/get-familiar-with-workspaces), and in this release Hugo finally gets solid support for it.

A common use case for a workspace is to simplify local development of a site with its theme modules.

A workspace can be configured in a `*.work` file and activated with the [module.workspace](https://gohugo.io/hugo-modules/configuration/) setting, which for this use is commonly controlled via the `HUGO_MODULE_WORKSPACE` OS environment variable.

See the [hugo.work](https://github.com/gohugoio/hugo/blob/master/hugo.work) file in the Hugo Docs repo for an example:

```
go 1.19

use .
use ../gohugoioTheme
```

Using the `use` directive, list all the modules you want to work on, pointing to its relative location. As in the example above, it's recommended to always include the main project (the ".") in the list.

With that you can start the Hugo server with that workspace enabled:

```
HUGO_MODULE_WORKSPACE=hugo.work hugo server --ignoreVendorPaths "**"
```

The `--ignoreVendorPaths` flag is added above to ignore any of the vendored dependencies inside `_vendor`. If you don't use vendoring, you don't need that flag. But now the server is set up watching the files and directories in the workspace and you can see your local edits reloaded.

### Breadcrumbs

We have added a new `.Ancestors` method on `Page` that walks up the tree to the home page. With this, breadcrumbs templates can be greatly simplified:

```handlebars
<ol>
  <ul>
    {{- range .Ancestors.Reverse }}
      <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
    {{- end }}
    <li class="active" aria-current="page">
      <a href="{{ .Permalink }}">{{ .Title }}</a>
    </li>
  </ul>
</ol>
```

### The path to /public now available in PostCSS

So you can do  `process.env.HUGO_PUBLISHDIR` in your `postcss.config.js` to figure out where Hugo publishes
its files.

Note that the value will always be an absolute file path and will point to a directory on disk even when running `hugo server` in memory mode.

If you write to this folder from PostCSS when running the server, you could run the server with one of these flags:

```
hugo server --renderToDisk
hugo server --renderStaticToDisk
```

## Note

* modules: Make the module.workspace=off as default (note) 0d4b17d4 @bep #10553 
* release: Add a note section in release notes 3afaca75 @bep 
* helpers: Allow at signs in UnicodeSanitize (note) 2d217cba @jmooring #10548 
* Also consider wrapped errors when checking for file IsNotExist errors ad205987 @bep #10534 

## Bug fixes

* tpl/resources: Fix data race in ToCSS aa2c7241 @bep #10542 
* tocss: Fix unquote case with double quotes 5d5f0a23 @septs #10555 
* resources/js: Fix some import discrepancies between Hugo and ESBuild b54de1bd @bep #10527 
* parser/metadecoders: Fix spelling e0e63f35 @lacamera 

## Improvements

* Adjust "you need the extended version" error message 180dfeba @bep 
* resource/page: Slight adjustment of Page.Ancestors eb0c8f9d @bep #10567 
* resource/page: Add Page.Ancestors 3a216186 @septs #10567 
* Annotate test assertions 71832328 @jmooring 
* hugolib: Exclude non-linkable pages from translations map 37ab1cf1 @jmooring #9073 
* Add HUGO_PUBLISHDIR to the Node environment 59af05ca @bep #10554 
* Revert "tpl/tplimpl: Use https in sitemap templates" 4989da65 @jmooring 
* tocss: Add some more test cases effa6a42 @bep #10555 
* Allow "fast render mode" even if --disableLiveReload is set d20d2651 @bep #10561 
* tocss: Add vars option 41a080b2 @bep #10555 
* modules: Improve "module workspace" not found error eda1e720 @bep 
* modules: Adjust watch logic vs workspace use definitions 330fa894 @bep 
* Add any configured Go Workspace file to the config watcher 6db52748 @bep #10556 
* parser/metadecoders: Remove superflous cast in test 17055d1f @bep 
* parser/metadecoders: Simplify nil check in Unmarshal 2a81a494 @bep 
* parser/metadecoders: Add empty /data JSON file as empty map e30d711c @acclassic #8601 
* tpl/openapi3: Wrap *kopenapi3.T 87e898a1 @bep 
* github: Use ruby/setup-ruby d8942698 @bep #10517 
* tpl/tplimpl: Use https in sitemap templates 3fd0b784 @jmooring #10515 

## Dependency Updates

* build(deps): bump golang.org/x/tools from 0.3.0 to 0.4.0 7874b968 @dependabot[bot] 

## Documentation

* docs: Regen docs helper JSON 10bb29d7 @bep 
* tpl: Improve template funcs GoDoc cd1ed563 @bep 

## Build Setup

* github: Update to Dart Sass 1.56.2 c9354d54 @bep 

[^1]: We're working on some bigger and even more exiting Hugo features that will be ready early next year. Stay tuned!


