### PR TITLE
[hugo-updater] Update Hugo to version 0.114.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.113.0"
+  HUGO_VERSION = "0.114.1"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.114.1
More details in https://github.com/gohugoio/hugo/releases/tag/v0.114.1

## Bug fixes

* Fix broken nodeploy setup 078226dd @bep #11149 
* commands: Make hugo env respect --logLevel b1016d2e @bep #11145 

## Improvements

* commands: Update Jekyll post-import output 49336bfc @brianknight10 #10715 

## Dependency Updates

* Revert "build(deps): bump gocloud.dev from 0.24.0 to 0.30.0" ae31dbdd @bep 
* build(deps): bump gocloud.dev from 0.24.0 to 0.30.0 94181829 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.18.4 to 0.18.5 5491e554 @dependabot[bot] 
* deps: Update github.com/tdewolff/minify/v2 v2.12.5 => v2.12.7 bf7af904 @jmooring #11132 

## Build Setup

* snap: Switch from Embedded Dart Sass to Dart Sass (#11146) 06d228aa @jmooring 


