### PR TITLE
[hugo-updater] Update Hugo to version 0.115.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.113.0"
+  HUGO_VERSION = "0.115.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.115.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.115.0

The notable new feature in this release is that you can now have permalink configuration also for section and taxonomy pages. Thanks to  @Mai-Lapyst for the implementation. See the [documentation](https://gohugo.io/content-management/urls/#permalinks) for more information.

## Bug fixes

* commands: Fix panic when running hugo new theme without theme name 635cc346 @deining #11162 
* Fix output formats and media type  per language config regression 79639c98 @bep #11159 
* common/collections: Fix append regression to allow appending nil b74b8d64 @khayyamsaleem #11180 
* commands: Fix help message for hugo new theme 793e38f5 @deining #11161 
* Fix false path warnings with resources.PostProcess fa0e16f4 @bep #7735 
* tpl/tplimpl: Fix typo in global variable name e3308a0b @alexandear 
* Fix broken nodeploy setup 5b4bfc2d @bep #11149 

## Improvements

* Misc permalinks adjustments 7917961d @bep #9448 #11184 #8523 
* commands: Handle hugo mod get --help 80ecb958 @bep #11141 
* Print help message when triggered with no flags 12646750 @roshanavand 
* Don't panic on invalid security whitelist regexp 7f698c89 @bep #11176 
* Merge branch 'master' of github.com:gohugoio/hugo bac03f40 @bep 
* resources/page: Allow section and taxonomy pages to have a permalink configuration cc14c6a5 @Mai-Lapyst #8523 
* commands: Enable format flag with hugo new site 019299b0 @jmooring #11155 

## Dependency Updates

* build(deps): bump github.com/evanw/esbuild from 0.18.5 to 0.18.10 9b313cec @dependabot[bot] 
* build(deps): bump github.com/niklasfasching/go-org from 1.6.6 to 1.7.0 92f55f11 @dependabot[bot] 

## Documentation

* Update README.md 58e09cc6 @jmooring 
* docs: Update permalinks documentation 12e4c4d5 @jmooring #8523 #10847 
* Update README.md 23ed087c @bep 

## Build Setup

* Merge branch 'release-0.114.1' a018259b @bep 


