### PR TITLE
[hugo-updater] Update Hugo to version 0.121.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.121.1"
+  HUGO_VERSION = "0.121.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.121.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.121.2

The main motivation behind this release is a security fix in the upstream [golang.org/x/crypto](https://github.com/golang/crypto/commit/9d2ee975ef9fe627bf0a6f01c1f69e8ef1d4f05d) library. We don't see how that CVE could be exploited via Hugo, but we do appreciate that many want to have a clean security report.

There's also some new features in this release:

* [AutoOrient image filter](https://gohugo.io/functions/images/autoorient/)
* [math.Rand](https://gohugo.io/functions/math/rand/)

## What's Changed

* build(deps): bump golang.org/x/crypto from 0.16.0 to 0.17.0 1ccd3147a @dependabot[bot] 
* tpl/math: Add math.Rand template function e40b9fbbc @jmooring #11833 
* resources/images: Create AutoOrient image filter 648d00c7d @jmooring #11717 
* all: Remove unused code 8adba648c @bep 


