### PR TITLE
[hugo-updater] Update Hugo to version 0.122.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.121.2"
+  HUGO_VERSION = "0.122.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.122.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.122.0

The big new thing in Hugo 0.122.0 is [ LaTeX or TeX typsetting](https://gohugo.io/content-management/mathematics/) directly from Markdown using standard syntax. Thanks to @j2kun and @jmooring for making this happen.

## Bug fixes

* tpl/tplimpl: Fix incorrect lastBuildDate 87bf2b968 @tastapod #11600 
* tpl: fix incorrect lastBuildDate f281ef8a4 @tastapod #11600 

## Improvements

* markup/goldmark: Support passthrough extension d0d2c6795 @j2kun #10894 
* parser/metadecoders: Accumulate org keywords into arrays 46f618756 @augustfengd #11743 
* Upgrade to Go 1.21.6 a541e3b4d @bep #11892 
* parser/metadecoders: Add CSV lazyQuotes option to transform.Unmarshal 912c6576b @jmooring #11884 

## Dependency Updates

* build(deps): bump golang.org/x/tools from 0.16.0 to 0.17.0 e0021f496 @dependabot[bot] 
* build(deps): bump github.com/rogpeppe/go-internal from 1.11.0 to 1.12.0 d25902c0d @dependabot[bot] 
* build(deps): bump github.com/pelletier/go-toml/v2 from 2.1.0 to 2.1.1 2dd608378 @dependabot[bot] 
* build(deps): bump github.com/evanw/esbuild from 0.19.8 to 0.19.12 45f52be7f @dependabot[bot] 
* deps: Update github.com/tdewolff/minify/v2 v2.20.9 => v2.20.13 891534307 @jtatum 

## Documentation

* docs: Regen docshelper 50042ee1f @bep 
* README: Update minimum Go version to 1.20 911bc60a7 @jmooring 


