### PR TITLE
[hugo-updater] Update Hugo to version 0.125.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.122.0"
+  HUGO_VERSION = "0.125.2"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.125.2
More details in https://github.com/gohugoio/hugo/releases/tag/v0.125.2

## What's Changed

* Only add root sections to the section pages menu 06d248910 @bep #12399 
* Fix partial rebuilds for SCSS fetched with GetMatch and similar Fixes #12395 004b69439 @bep 
* commands: Add gen chromastyles --lineNumbersTableStyle flag da6112fc6 @jmooring #12393 
* resources/images: Fix TestColorLuminance on s390x faf9fedc3 @bep 
* commands: Provide examples for chromastyles flags 11aa89319 @jmooring #12387 


