### PR TITLE
[hugo-updater] Update Hugo to version 0.126.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.125.2"
+  HUGO_VERSION = "0.126.3"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.126.3
More details in https://github.com/gohugoio/hugo/releases/tag/v0.126.3

* content adapter: Fix site.GetPage using the base part of the path 917199a94 @bep #12561 
* resources/page: Deprecate .Sites.First in favor of .Sites.Default c8dac67de @jmooring #12513 
* metrics: Increase maximum length of cumulative duration to 15 0068f0329 @razonyang 
* content adapter: Handle more separator in content.value 0221ddb39 @bep #12556 


