### PR TITLE
[hugo-updater] Update Hugo to version 0.138.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.131.0"
+  HUGO_VERSION = "0.138.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.138.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.138.0

