### PR TITLE
[hugo-updater] Update Hugo to version 0.156.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
   command = "hugo --gc --minify -b $URL"
 
 [build.environment]
-  HUGO_VERSION = "0.155.3"
+  HUGO_VERSION = "0.156.0"
   HUGO_ENABLEGITINFO = "true"
 
 [context.deploy-preview]


### PR DESCRIPTION
[hugo-updater] Update Hugo to version 0.156.0
More details in https://github.com/gohugoio/hugo/releases/tag/v0.156.0

